### PR TITLE
Redpanda: fix advertised address

### DIFF
--- a/src/test/kotlin/com/example/kafkademoissue/testcontainers/RedpandaContainer.kt
+++ b/src/test/kotlin/com/example/kafkademoissue/testcontainers/RedpandaContainer.kt
@@ -21,7 +21,7 @@ class RedpandaContainer : GenericContainer<RedpandaContainer?>("vectorized/redpa
         command += "/usr/bin/rpk redpanda start --overprovisioned --smp 1 --reserve-memory 0M --node-id 0 "
         command += "--kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092 "
         command += "--pandaproxy-addr 0.0.0.0:8084 "
-        command += "--advertise-kafka-addr PLAINTEXT://redpanda:29092,OUTSIDE://" + host.toString() + ":" + getMappedPort(9092)
+        command += "--advertise-kafka-addr PLAINTEXT://" + host.toString() + ":29092,OUTSIDE://" + host.toString() + ":" + getMappedPort(9092)
         copyFileToContainer(
             Transferable.of(command.toByteArray(), 511),
             STARTER_SCRIPT


### PR DESCRIPTION
The `PLAINTEXT` listener (it should be called `INTERNAL`, really) from the docker example is intended for use within the docker network, and `EXTERNAL` is intended to be used from the host machine.

I don't know a great deal about `testcontainers`, but I suspect that when using Docker Machine the `EXTERNAL` endpoint should use `getTestHostIpAddress()` for the host, but on my machine (Ubuntu, Docker), it throws an exception that it's not implemented.

Signed-off-by: Ben Pope <ben@vectorized.io>